### PR TITLE
requeue-if-network-is-not-set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Wait until the `GCPCLuster` has network link in status field.
+
 ### Removed
 
 - No need for a k8s client on the firewall client.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Wait until the `GCPCLuster` has network link in status field.
+
 ## [0.2.1] - 2022-06-22
 
 ### Fixed

--- a/controllers/gcpcluster.go
+++ b/controllers/gcpcluster.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"time"
 
 	"github.com/giantswarm/microerror"
 	"github.com/go-logr/logr"
@@ -69,6 +70,10 @@ func (r *GCPClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if cluster == nil {
 		log.Info("GCP Cluster does not have an owner cluster yet")
 		return ctrl.Result{}, nil
+	}
+	if *gcpCluster.Status.Network.SelfLink == "" {
+		log.Info("GCP Cluster does not have network set yet")
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 30}, nil
 	}
 
 	if annotations.IsPaused(cluster, gcpCluster) {

--- a/controllers/gcpcluster.go
+++ b/controllers/gcpcluster.go
@@ -71,7 +71,7 @@ func (r *GCPClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		log.Info("GCP Cluster does not have an owner cluster yet")
 		return ctrl.Result{}, nil
 	}
-	if gcpCluster.Status.Network == nil || *gcpCluster.Status.Network.SelfLink == "" {
+	if gcpCluster.Status.Network.SelfLink == nil || *gcpCluster.Status.Network.SelfLink == "" {
 		log.Info("GCP Cluster does not have network set yet")
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 30}, nil
 	}

--- a/controllers/gcpcluster.go
+++ b/controllers/gcpcluster.go
@@ -71,7 +71,7 @@ func (r *GCPClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		log.Info("GCP Cluster does not have an owner cluster yet")
 		return ctrl.Result{}, nil
 	}
-	if *gcpCluster.Status.Network.SelfLink == "" {
+	if gcpCluster.Status.Network == nil || *gcpCluster.Status.Network.SelfLink == "" {
 		log.Info("GCP Cluster does not have network set yet")
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 30}, nil
 	}


### PR DESCRIPTION
the network self link is used in the firewall rule reference so its needed for the firewall rule creation