### PR TITLE
Ignore missing allowlist annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Do not error if bastion allowlist annotation is missing for backwards compatibility.
+
 ## [0.4.0] - 2022-07-20
 
 ### Changed

--- a/controllers/gcpcluster.go
+++ b/controllers/gcpcluster.go
@@ -174,7 +174,8 @@ func getBastionFirewallRuleName(clusterName string) string {
 func getIPRangesFromAnnotation(logger logr.Logger, gcpCluster *capg.GCPCluster) ([]string, error) {
 	annotation, ok := gcpCluster.Annotations[AnnotationBastionAllowListSubnets]
 	if !ok {
-		return nil, fmt.Errorf("%s annotation is empty", AnnotationBastionAllowListSubnets)
+		logger.Info("Cluster does not have bastion allow list annotation. Using cloud default.")
+		return nil, nil
 	}
 
 	ipRanges := strings.Split(annotation, ",")

--- a/tests/common.go
+++ b/tests/common.go
@@ -52,13 +52,15 @@ func DeleteFirewall(firewalls *compute.FirewallsClient, gcpProject, firewallName
 		Project:  gcpProject,
 	}
 
-	// Explicitly do not wait for the deletion to complete. This makes the
-	// tests significantly slower
-	_, err := firewalls.Delete(context.Background(), req)
+	op, err := firewalls.Delete(context.Background(), req)
 	Expect(err).WithOffset(1).To(Or(
 		Not(HaveOccurred()),
 		BeGoogleAPIErrorWithStatus(http.StatusNotFound),
 	))
+
+	if op != nil {
+		Expect(op.Wait(context.Background())).WithOffset(1).To(Succeed())
+	}
 }
 
 func DeleteNetwork(networks *compute.NetworksClient, gcpProject, networkName string) {


### PR DESCRIPTION
This is for backwards compatibility. Older versions of cluster-gcp do
not have this annotation set and the operator errors. An empty list is
still invalid though