### PR TITLE
Update security policy rules properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Manually list NAT IPs and filter instead of getting them from the Router.
+- Fix adding and removing the allowlist annotation failing for security rules
 
 ## [0.5.0] - 2022-08-23
 

--- a/pkg/security/client.go
+++ b/pkg/security/client.go
@@ -91,18 +91,17 @@ func (c *Client) setSecurityPolicy(ctx context.Context, cluster *capg.GCPCluster
 func (c *Client) applySecurityPolicy(ctx context.Context, logger logr.Logger, cluster *capg.GCPCluster, policy Policy) (*computepb.SecurityPolicy, error) {
 	securityPolicy := toGCPSecurityPolicy(cluster, policy)
 
-	err := c.createSecurityPolicy(ctx, cluster, securityPolicy)
+	gcpPolicy, err := c.createSecurityPolicy(ctx, cluster, securityPolicy)
 	if google.HasHttpCode(err, http.StatusConflict) {
 		logger.Info("securityPolicy already exists. Updating")
-		err = c.updateSecurityPolicy(ctx, cluster, securityPolicy)
+		return c.updateSecurityPolicy(ctx, cluster, securityPolicy)
 	}
 
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	// Getting the policy is necessary to populate the SelfLink
-	return c.getSecurityPolicy(ctx, cluster, policy.Name)
+	return gcpPolicy, nil
 }
 
 func (c *Client) DeletePolicy(ctx context.Context, cluster *capg.GCPCluster, name string) error {
@@ -133,7 +132,7 @@ func (c *Client) DeletePolicy(ctx context.Context, cluster *capg.GCPCluster, nam
 	return errors.WithStack(err)
 }
 
-func (c *Client) createSecurityPolicy(ctx context.Context, cluster *capg.GCPCluster, policy *computepb.SecurityPolicy) error {
+func (c *Client) createSecurityPolicy(ctx context.Context, cluster *capg.GCPCluster, policy *computepb.SecurityPolicy) (*computepb.SecurityPolicy, error) {
 	req := &computepb.InsertSecurityPolicyRequest{
 		Project:                cluster.Spec.Project,
 		SecurityPolicyResource: policy,
@@ -141,11 +140,16 @@ func (c *Client) createSecurityPolicy(ctx context.Context, cluster *capg.GCPClus
 
 	op, err := c.securityPolicies.Insert(ctx, req)
 	if err != nil {
-		return errors.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
 
 	err = op.Wait(ctx)
-	return errors.WithStack(err)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	// Getting the policy is necessary to populate the SelfLink.
+	return c.getSecurityPolicy(ctx, cluster, *policy.Name)
 }
 
 func (c *Client) getSecurityPolicy(ctx context.Context, cluster *capg.GCPCluster, name string) (*computepb.SecurityPolicy, error) {
@@ -156,32 +160,124 @@ func (c *Client) getSecurityPolicy(ctx context.Context, cluster *capg.GCPCluster
 	return c.securityPolicies.Get(ctx, req)
 }
 
-func (c *Client) updateSecurityPolicy(ctx context.Context, cluster *capg.GCPCluster, policy *computepb.SecurityPolicy) error {
+func (c *Client) updateSecurityPolicy(ctx context.Context, cluster *capg.GCPCluster, policy *computepb.SecurityPolicy) (*computepb.SecurityPolicy, error) {
+	currentPolicy, err := c.getSecurityPolicy(ctx, cluster, *policy.Name)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	// There are three groups of rules - new rules, rules we want to update and
+	// rules that we want to delete. Rules that are in the current policy, but
+	// not in the new one should be deleted.
+	// We start of by marking all the rules in the current policy for deletion.
+	rulesToDelete := constructRulePriorityMap(currentPolicy.Rules)
 	for _, rule := range policy.Rules {
-		req := &computepb.PatchRuleSecurityPolicyRequest{
-			Priority:                   rule.Priority,
-			Project:                    cluster.Spec.Project,
-			SecurityPolicy:             *policy.Name,
-			SecurityPolicyRuleResource: rule,
-		}
-		op, err := c.securityPolicies.PatchRule(ctx, req)
-		if err != nil {
-			return errors.WithStack(err)
+		priority := *rule.Priority
+
+		// If both the new and old policy contain a rule with the same
+		// priority, then patch that rule and remove it from the rules that
+		// need to be deleted.
+		// If a rule is only in the new policy then it needs to be created.
+		// NOTE: We can't check for 404 when patching the rule. GCP will always
+		// return 400 if a rule doesn't exist. This also applies to `GetRule`
+		_, ok := rulesToDelete[priority]
+		if ok {
+			delete(rulesToDelete, priority)
+			err = c.patchRule(ctx, cluster, policy, rule)
+			if err != nil {
+				return nil, errors.WithStack(err)
+			}
+
+			continue
 		}
 
-		err = op.Wait(ctx)
+		err = c.createRule(ctx, cluster, policy, rule)
 		if err != nil {
-			return errors.WithStack(err)
+			return nil, errors.WithStack(err)
 		}
 	}
 
+	for rulePriority := range rulesToDelete {
+		// The default has priority MaxInt32 and cannot be deleted
+		if rulePriority == math.MaxInt32 {
+			continue
+		}
+
+		err = c.deleteRule(ctx, cluster, policy, rulePriority)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+	}
+
+	selfLink := *currentPolicy.SelfLink
+	policy.SelfLink = &selfLink
+	return policy, nil
+}
+
+func (c *Client) createRule(ctx context.Context, cluster *capg.GCPCluster, policy *computepb.SecurityPolicy, rule *computepb.SecurityPolicyRule) error {
+	req := &computepb.AddRuleSecurityPolicyRequest{
+		Project:                    cluster.Spec.Project,
+		SecurityPolicy:             *policy.Name,
+		SecurityPolicyRuleResource: rule,
+	}
+	op, err := c.securityPolicies.AddRule(ctx, req)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	err = op.Wait(ctx)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
 	return nil
+}
+
+func (c *Client) patchRule(ctx context.Context, cluster *capg.GCPCluster, policy *computepb.SecurityPolicy, rule *computepb.SecurityPolicyRule) error {
+	req := &computepb.PatchRuleSecurityPolicyRequest{
+		Priority:                   rule.Priority,
+		Project:                    cluster.Spec.Project,
+		SecurityPolicy:             *policy.Name,
+		SecurityPolicyRuleResource: rule,
+	}
+	op, err := c.securityPolicies.PatchRule(ctx, req)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	err = op.Wait(ctx)
+	return errors.WithStack(err)
+}
+
+func (c *Client) deleteRule(ctx context.Context, cluster *capg.GCPCluster, policy *computepb.SecurityPolicy, rulePriority int32) error {
+	req := &computepb.RemoveRuleSecurityPolicyRequest{
+		Priority:       &rulePriority,
+		Project:        cluster.Spec.Project,
+		SecurityPolicy: *policy.Name,
+	}
+
+	op, err := c.securityPolicies.RemoveRule(ctx, req)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	err = op.Wait(ctx)
+	return errors.WithStack(err)
 }
 
 func (c *Client) getLogger(ctx context.Context, ruleName string) logr.Logger {
 	logger := log.FromContext(ctx)
 	logger = logger.WithName("security-client")
 	return logger.WithValues("name", ruleName)
+}
+
+func constructRulePriorityMap(rules []*computepb.SecurityPolicyRule) map[int32]struct{} {
+	priorityMap := map[int32]struct{}{}
+	for _, rule := range rules {
+		priorityMap[*rule.Priority] = struct{}{}
+	}
+
+	return priorityMap
 }
 
 func toGCPSecurityPolicy(cluster *capg.GCPCluster, policy Policy) *computepb.SecurityPolicy {

--- a/pkg/security/client.go
+++ b/pkg/security/client.go
@@ -24,7 +24,7 @@ const (
 
 	DefaultRuleDescription = "Default rule, higher priority overrides it"
 	DefaultRuleIPRanges    = "*"
-	DefaultRulePriority    = math.MaxInt32
+	DefaultRulePriority    = int32(math.MaxInt32)
 )
 
 type Policy struct {

--- a/pkg/security/client.go
+++ b/pkg/security/client.go
@@ -24,6 +24,7 @@ const (
 
 	DefaultRuleDescription = "Default rule, higher priority overrides it"
 	DefaultRuleIPRanges    = "*"
+	DefaultRulePriority    = math.MaxInt32
 )
 
 type Policy struct {
@@ -198,8 +199,8 @@ func (c *Client) updateSecurityPolicy(ctx context.Context, cluster *capg.GCPClus
 	}
 
 	for rulePriority := range rulesToDelete {
-		// The default has priority MaxInt32 and cannot be deleted
-		if rulePriority == math.MaxInt32 {
+		// The default rule cannot be deleted
+		if rulePriority == DefaultRulePriority {
 			continue
 		}
 
@@ -313,6 +314,6 @@ func getDefaultRule(defaultAction string) *computepb.SecurityPolicyRule {
 			},
 			VersionedExpr: to.StringP(SecurityPolicyVersionedExpr),
 		},
-		Priority: to.Int32P(math.MaxInt32),
+		Priority: to.Int32P(DefaultRulePriority),
 	}
 }

--- a/tests/acceptance/firewalls_test.go
+++ b/tests/acceptance/firewalls_test.go
@@ -3,7 +3,6 @@ package acceptance_test
 import (
 	"context"
 	"fmt"
-	"math"
 	"net/http"
 	"time"
 
@@ -241,7 +240,7 @@ var _ = Describe("Firewalls", func() {
 		defaultRule := securityPolicy.Rules[3]
 		Expect(*defaultRule.Action).To(Equal(security.ActionDeny403))
 		Expect(*defaultRule.Description).To(Equal(security.DefaultRuleDescription))
-		Expect(*defaultRule.Priority).To(Equal(int32(math.MaxInt32)))
+		Expect(*defaultRule.Priority).To(Equal(security.DefaultRulePriority))
 		Expect(defaultRule.Match).NotTo(BeNil())
 		Expect(defaultRule.Match.Config).NotTo(BeNil())
 		Expect(defaultRule.Match.Config.SrcIpRanges).To(ConsistOf(security.DefaultRuleIPRanges))

--- a/tests/integration/security/client_test.go
+++ b/tests/integration/security/client_test.go
@@ -145,6 +145,14 @@ var _ = Describe("Client", func() {
 					"10.1.0.0/24",
 					"172.158.1.0/24",
 				}
+				policy.Rules = append(policy.Rules, security.PolicyRule{
+					Action:      security.ActionAllow,
+					Description: tests.TestDescription,
+					SourceIPRanges: []string{
+						"10.255.0.0/24",
+					},
+					Priority: 3,
+				})
 			})
 
 			It("updates the rule", func() {
@@ -160,9 +168,9 @@ var _ = Describe("Client", func() {
 
 				Expect(*securityPolicy.Name).To(Equal(name))
 				Expect(*securityPolicy.Description).To(Equal(tests.TestDescription))
-				Expect(securityPolicy.Rules).To(HaveLen(2))
+				Expect(securityPolicy.Rules).To(HaveLen(3))
 
-				By("creating the rules in the policy")
+				By("updating the rules in the policy")
 				rule := securityPolicy.Rules[0]
 				Expect(*rule.Action).To(Equal(security.ActionDeny403))
 				Expect(*rule.Description).To(Equal(tests.TestDescription))
@@ -174,9 +182,48 @@ var _ = Describe("Client", func() {
 					"172.158.1.0/24",
 				))
 
-				By("creating the rules in the policy")
+				By("updating the default rule")
 				defaultRule := securityPolicy.Rules[1]
 				Expect(*defaultRule.Action).To(Equal(security.ActionAllow))
+
+				By("creating the new rule in the policy")
+				newRule := securityPolicy.Rules[2]
+				Expect(*newRule.Action).To(Equal(security.ActionAllow))
+				Expect(*newRule.Description).To(Equal(tests.TestDescription))
+				Expect(*newRule.Priority).To(Equal(int32(3)))
+				Expect(newRule.Match).NotTo(BeNil())
+				Expect(newRule.Match.Config).NotTo(BeNil())
+				Expect(newRule.Match.Config.SrcIpRanges).To(ConsistOf(
+					"10.255.0.0/24",
+				))
+			})
+
+			When("the policy removes a rule", func() {
+				BeforeEach(func() {
+					policy.Rules = []security.PolicyRule{}
+				})
+
+				It("removes the rule", func() {
+					err := client.ApplyPolicy(ctx, cluster, policy)
+					Expect(err).NotTo(HaveOccurred())
+
+					getSecurityPolicy := &computepb.GetSecurityPolicyRequest{
+						Project:        gcpProject,
+						SecurityPolicy: name,
+					}
+					securityPolicy, err := securityPolicies.Get(ctx, getSecurityPolicy)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(*securityPolicy.Name).To(Equal(name))
+					Expect(*securityPolicy.Description).To(Equal(tests.TestDescription))
+					Expect(securityPolicy.Rules).To(HaveLen(1))
+
+					By("updating the default rule")
+					defaultRule := securityPolicy.Rules[0]
+					Expect(*defaultRule.Action).To(Equal(security.ActionAllow))
+					Expect(*defaultRule.Description).To(Equal(security.DefaultRuleDescription))
+					Expect(*defaultRule.Priority).To(Equal(int32(math.MaxInt32)))
+				})
 			})
 		})
 

--- a/tests/integration/security/client_test.go
+++ b/tests/integration/security/client_test.go
@@ -2,7 +2,6 @@ package security_test
 
 import (
 	"context"
-	"math"
 	"net/http"
 	"time"
 
@@ -119,7 +118,7 @@ var _ = Describe("Client", func() {
 			defaultRule := securityPolicy.Rules[1]
 			Expect(*defaultRule.Action).To(Equal(security.ActionDeny403))
 			Expect(*defaultRule.Description).To(Equal(security.DefaultRuleDescription))
-			Expect(*defaultRule.Priority).To(Equal(int32(math.MaxInt32)))
+			Expect(*defaultRule.Priority).To(Equal(security.DefaultRulePriority))
 			Expect(defaultRule.Match).NotTo(BeNil())
 			Expect(defaultRule.Match.Config).NotTo(BeNil())
 			Expect(defaultRule.Match.Config.SrcIpRanges).To(ConsistOf(security.DefaultRuleIPRanges))
@@ -222,7 +221,7 @@ var _ = Describe("Client", func() {
 					defaultRule := securityPolicy.Rules[0]
 					Expect(*defaultRule.Action).To(Equal(security.ActionAllow))
 					Expect(*defaultRule.Description).To(Equal(security.DefaultRuleDescription))
-					Expect(*defaultRule.Priority).To(Equal(int32(math.MaxInt32)))
+					Expect(*defaultRule.Priority).To(Equal(security.DefaultRulePriority))
 				})
 			})
 		})


### PR DESCRIPTION
This solves the problem of someone either removing or adding the
allowlist annotation. Without this change the opeartor fails with 400
when trying to patch a rule that doesn't exist.