### PR TITLE
Allow empty annotation

### DIFF
--- a/pkg/cidr/cidr.go
+++ b/pkg/cidr/cidr.go
@@ -8,6 +8,10 @@ import (
 )
 
 func ParseFromCommaSeparated(value string) ([]string, error) {
+	if value == "" {
+		return nil, nil
+	}
+
 	ipRanges := strings.Split(value, ",")
 	for _, cidr := range ipRanges {
 		_, _, err := net.ParseCIDR(cidr)


### PR DESCRIPTION
This allows us to create our clusters without setting this and just use
the defaults