### PR TITLE
Skip event when backend service is not delete yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Manually list NAT IPs and filter instead of getting them from the Router.
 - Fix adding and removing the allowlist annotation failing for security rules
+- Do not error if backend service isn't deleted when reconciling delete event. Instead just skip the event
 
 ## [0.5.0] - 2022-08-23
 


### PR DESCRIPTION
The reconciler errors otherwise.
Also skip if Router isn't available before creating the security policy