### PR TITLE
Only apply PSP is object is registered in the k8s API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `PodSecurityPolicy` are removed on newer k8s versions, so only apply it if object is registered in the k8s API.
+
 ## [0.5.1] - 2022-09-02
 
 ### Added

--- a/helm/capg-firewall-rule-operator/templates/psp.yaml
+++ b/helm/capg-firewall-rule-operator/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -26,3 +27,4 @@ spec:
   hostNetwork: false
   hostIPC: false
   hostPID: false
+{{- end }}

--- a/helm/capg-firewall-rule-operator/templates/rbac.yaml
+++ b/helm/capg-firewall-rule-operator/templates/rbac.yaml
@@ -41,6 +41,7 @@ roleRef:
   name: {{ include "resource.default.name"  . }}
   apiGroup: rbac.authorization.k8s.io
 ---
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -49,7 +50,7 @@ metadata:
   {{- include "labels.common" . | nindent 4 }}
 rules:
   - apiGroups:
-      - extensions
+      - policy
     resources:
       - podsecuritypolicies
     verbs:
@@ -71,3 +72,4 @@ roleRef:
   kind: ClusterRole
   name: {{ include "resource.psp.name" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}


### PR DESCRIPTION
`PodSecurityPolicy` are removed on newer k8s versions, so only apply it if object is registered in the k8s API.